### PR TITLE
Include URL in log payload

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,7 +15,9 @@
         </whitelist>
     </filter>
     <php>
+        <server name="APP_DEBUG" value="true"/>
         <server name="APP_ENV" value="testing"/>
+        <server name="APP_URL" value="http://localhost"/>
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
         <!-- <server name="DB_CONNECTION" value="sqlite"/> -->

--- a/src/LogRoute.php
+++ b/src/LogRoute.php
@@ -13,6 +13,7 @@ class LogRoute
     {
         Lazarus::log([
             'route' => Route::currentRouteName(),
+            'url' => $request->url(),
             'ip_address' => $request->ip(),
             'timestamp' => now()->toDateTimeString(),
         ]);

--- a/tests/LazarusLoggerTest.php
+++ b/tests/LazarusLoggerTest.php
@@ -4,7 +4,6 @@ namespace Lazarus\Tests;
 
 use Lazarus\Laravel\LazarusLogger;
 use Lazarus\Laravel\LazarusService;
-use Orchestra\Testbench\TestCase;
 
 class LazarusLoggerTest extends TestCase
 {

--- a/tests/LogRouteTest.php
+++ b/tests/LogRouteTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Lazarus\Tests;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use Lazarus\Laravel\Facades\Lazarus;
+
+class LogRouteTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('lazarus.token', Str::random(60));
+    }
+
+    public function test_log_payload()
+    {
+        Carbon::setTestNow('2020-10-01 13:00:00');
+
+        Lazarus::shouldReceive('log')
+            ->once()
+            ->with([
+                'route' => 'api.test.index',
+                'url' => 'http://localhost/test',
+                'ip_address' => '135.53.70.123',
+                'timestamp' => '2020-10-01 13:00:00',
+            ])
+            ->andReturnNull();
+
+        Route::get('/test', function () {
+            return 'Test';
+        })->middleware('api')->name('api.test.index');
+
+        $this->getJson('/test', [
+            'REMOTE_ADDR' => '135.53.70.123',
+        ])
+            ->assertSuccessful();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lazarus\Tests;
+
+use Lazarus\Laravel\Facades\Lazarus;
+use Lazarus\Laravel\LazarusServiceProvider;
+
+class TestCase extends \Orchestra\Testbench\TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [LazarusServiceProvider::class];
+    }
+
+    protected function getPackageAliases($app)
+    {
+        return [
+            'Lazarus' => Lazarus::class,
+        ];
+    }
+}


### PR DESCRIPTION
This adds the current URL (without query parameters) to the log payload.